### PR TITLE
This makes it so we can actually be in development mode.

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -50,11 +50,11 @@ module Tint
 
 		enable :sessions
 		set :session_secret, ENV["SESSION_SECRET"]
-		set :environment, Sprockets::Environment.new
+		set :sprockets, Sprockets::Environment.new
 		set :method_override, true
 
-		environment.append_path "assets/stylesheets"
-		environment.css_compressor = :scss
+		sprockets.append_path "assets/stylesheets"
+		sprockets.css_compressor = :scss
 
 		current_user do
 			session['user']
@@ -107,7 +107,7 @@ module Tint
 		get "/assets/*" do
 			skip_authorization
 			env["PATH_INFO"].sub!("/assets", "")
-			settings.environment.call(env)
+			settings.sprockets.call(env)
 		end
 
 		post "/build" do


### PR DESCRIPTION
I copied the code for sprockets from a sinatra recipe, but when I set
the environment to that it means our app won't run in development mode
by default, which means we don't get nice stack traces or anything like
that. It also means the auto reload plugin doesn't work, and now it
should.

Turns out you can just call it sprockets and change the references
elsewhere and everything works fine.