### PR TITLE
Add the ability to use a multiple select box.

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -283,7 +283,7 @@ module Tint
 		def process_form_data(data, git)
 			case data
 			when Array
-				data.reject { |v| v.is_a?(String) && v.blank? }.map { |v| process_form_data(v, git) }
+				data.reject { |v| v.is_a?(String) && v.strip == "" }.map { |v| process_form_data(v, git) }
 			when Hash
 				if data.keys.include?(:filename) && data.keys.include?(:tempfile)
 					uploads_path = PROJECT_PATH.join("uploads").join(Time.now.strftime("%Y"))

--- a/app/app.rb
+++ b/app/app.rb
@@ -283,7 +283,7 @@ module Tint
 		def process_form_data(data, git)
 			case data
 			when Array
-				data.map { |v| process_form_data(v, git) }
+				data.reject { |v| v.is_a?(String) && v.blank? }.map { |v| process_form_data(v, git) }
 			when Hash
 				if data.keys.include?(:filename) && data.keys.include?(:tempfile)
 					uploads_path = PROJECT_PATH.join("uploads").join(Time.now.strftime("%Y"))


### PR DESCRIPTION
If the YML key is the same name as a key from the .tint.yml options
hash, we will display a multiselect. This also takes precedence over
normal array input displays.

There is a hidden input to submit an array, because if you select
nothing in the multiselect that will not submit to the server, which
results in the key being deleted. The hidden input fixes this behaviour.
Because the hidden input submits an array with one entry that has a
value of "" we now reject blank values in our process_form_data method.

Closes #15 