### PR TITLE
Allow a project to not have the .tint.yml file

### DIFF
--- a/app/future.rb
+++ b/app/future.rb
@@ -1,0 +1,9 @@
+unless {}.respond_to?(:dig)
+	class Hash
+		def dig(*args)
+			args.reduce(self) do |h, k|
+				h && h[k]
+			end
+		end
+	end
+end

--- a/app/helpers.rb
+++ b/app/helpers.rb
@@ -1,4 +1,5 @@
 require 'active_support/inflector/methods'
+require_relative 'future'
 
 module Tint
 	module Helpers
@@ -53,9 +54,9 @@ module Tint
 					"<input type='date' name='#{name}' value='#{date && date.strftime("%F")}' />"
 				elsif value.is_a?(String) && value.length > 50
 					"<textarea name='#{name}'>#{value}</textarea>"
-				elsif key && (options = site.config["options"][ActiveSupport::Inflector.pluralize(key)])
+				elsif key && (options = site.config.dig("options", ActiveSupport::Inflector.pluralize(key)))
 					render_select(name, value, options)
-				elsif key && (options = site.config["options"][key])
+				elsif key && (options = site.config.dig("options", key))
 					render_multiple_select(name, value, options)
 				else
 					"<input type='text' name='#{name}' value='#{value}' />"
@@ -120,7 +121,7 @@ module Tint
 			end
 
 			def multiple_select?(key)
-				!!site.config["options"][key]
+				!!site.config.dig("options", key)
 			end
 		end
 	end

--- a/app/site.rb
+++ b/app/site.rb
@@ -26,7 +26,7 @@ module Tint
 		end
 
 		def config
-			@config ||= YAML.safe_load(open(cache_path.join(".tint.yml")), [Date, Time])
+			@config ||= YAML.safe_load(open(cache_path.join(".tint.yml")), [Date, Time]) rescue {}
 		end
 
 		def file(path)


### PR DESCRIPTION
If there is no .tint.yml or it does not have the "options" key, we
should not blow up.  Backport dig from ruby2.3 to support this.