### PR TITLE
Refactor the global constants to use Tint::Site

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,7 +3,7 @@ SESSION_SECRET=
 APP_URL=
 
 # For standalone mode
-PROJECT_PATH=
+SITE_PATH=
 
 # Optional
 GITHUB_KEY=

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,3 @@ DEPENDENCIES
   sinatra-pundit
   sprockets
   sqlite3
-
-BUNDLED WITH
-   1.12.5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-Copy `.env.sample` to `.env` and set `PROJECT_PATH` to the path of a jekyll app on your system.
+Copy `.env.sample` to `.env` and set `SITE_PATH` to the path of a jekyll app's git repo on your system.
 
 Run the app using `rackup`.
 

--- a/app/directory.rb
+++ b/app/directory.rb
@@ -10,19 +10,19 @@ module Tint
 		end
 
 		def user_id
-			@site.user_id
+			site.user_id
 		end
 
 		def route
-			@site.route("files/#{relative_path}")
+			site.route("files/#{relative_path}")
 		end
 
 		def path
 			unless @path
 				# Use realdirpath so that it works if directory does not exist
-				@path = @site.cache_path.join(relative_path).realdirpath
+				@path = site.cache_path.join(relative_path).realdirpath
 
-				unless @path.to_s.start_with?(@site.cache_path.to_s)
+				unless @path.to_s.start_with?(site.cache_path.to_s)
 					raise "File is outside of project scope!"
 				end
 			end
@@ -31,7 +31,7 @@ module Tint
 		end
 
 		def file(path)
-			@site.file(relative_path.join(path))
+			site.file(relative_path.join(path))
 		end
 
 		def files
@@ -40,7 +40,7 @@ module Tint
 			files = path.children(false).map(&method(:file))
 
 			if relative_path.to_s != "."
-				parent = Tint::File.new(@site, relative_path.dirname, "..")
+				parent = Tint::File.new(site, relative_path.dirname, "..")
 				files.unshift(parent)
 			end
 
@@ -54,7 +54,12 @@ module Tint
 				end
 			end
 
-			@site.file(relative_path.join(file[:filename]))
+			site.file(relative_path.join(file[:filename]))
 		end
+
+	protected
+
+		attr_reader :site
+
 	end
 end

--- a/app/file.rb
+++ b/app/file.rb
@@ -6,27 +6,25 @@ require_relative "directory"
 
 module Tint
 	class File
-		attr_reader :path
+		attr_reader :relative_path
 
-		def initialize(path, name=nil)
-			@path = Pathname.new(path).realpath.cleanpath
-			unless @path.to_s.start_with?(PROJECT_PATH.to_s)
-				raise "File is outside of project scope!"
-			end
+		def initialize(site, relative_path, name=nil)
+			@site = site
+			@relative_path = Pathname.new(relative_path).cleanpath
 
 			@name = name
 		end
 
-		def self.get(params)
-			Tint::File.new(PROJECT_PATH.join(params['splat'].join('/')))
+		def user_id
+			@site.user_id
 		end
 
 		def directory?
-			::File.directory?(path)
+			path.directory?
 		end
 
 		def parent
-			@parent ||= Tint::Directory.new(path.dirname)
+			@parent ||= Tint::Directory.new(@site, relative_path.dirname)
 		end
 
 		def text?
@@ -43,16 +41,20 @@ module Tint
 			[".yaml", ".yml"].include? extension
 		end
 
-		def root?
-			path == PROJECT_PATH
-		end
-
 		def route
-			"/files/#{relative_path}"
+			@site.route("files/#{relative_path}")
 		end
 
-		def relative_path
-			path.relative_path_from(PROJECT_PATH)
+		def path
+			unless @path
+				@path = @site.cache_path.join(relative_path).realdirpath
+
+				unless @path.to_s.start_with?(@site.cache_path.to_s)
+					raise "File is outside of project scope!"
+				end
+			end
+
+			@path
 		end
 
 		def name
@@ -60,7 +62,7 @@ module Tint
 		end
 
 		def stream
-			::File.foreach(path).with_index do |line, idx|
+			path.each_line.with_index do |line, idx|
 				yield line.chomp, idx
 			end
 		end
@@ -92,7 +94,7 @@ module Tint
 		end
 
 		def to_directory
-			Tint::Directory.new(path)
+			Tint::Directory.new(@site, relative_path)
 		end
 
 	protected
@@ -105,7 +107,7 @@ module Tint
 			return @content_or_frontmatter if @content_or_frontmatter
 
 			has_frontmatter = false
-			::File.foreach(path).with_index do |line, idx|
+			path.each_line.with_index do |line, idx|
 				line.chomp!
 				if line == '---' && idx == 0
 					has_frontmatter = true

--- a/app/file.rb
+++ b/app/file.rb
@@ -16,7 +16,7 @@ module Tint
 		end
 
 		def user_id
-			@site.user_id
+			site.user_id
 		end
 
 		def directory?
@@ -24,7 +24,7 @@ module Tint
 		end
 
 		def parent
-			@parent ||= Tint::Directory.new(@site, relative_path.dirname)
+			@parent ||= Tint::Directory.new(site, relative_path.dirname)
 		end
 
 		def text?
@@ -42,14 +42,14 @@ module Tint
 		end
 
 		def route
-			@site.route("files/#{relative_path}")
+			site.route("files/#{relative_path}")
 		end
 
 		def path
 			unless @path
-				@path = @site.cache_path.join(relative_path).realdirpath
+				@path = site.cache_path.join(relative_path).realdirpath
 
-				unless @path.to_s.start_with?(@site.cache_path.to_s)
+				unless @path.to_s.start_with?(site.cache_path.to_s)
 					raise "File is outside of project scope!"
 				end
 			end
@@ -94,7 +94,7 @@ module Tint
 		end
 
 		def to_directory
-			Tint::Directory.new(@site, relative_path)
+			Tint::Directory.new(site, relative_path)
 		end
 
 	protected
@@ -121,5 +121,8 @@ module Tint
 
 			@content_or_frontmatter = [!has_frontmatter, has_frontmatter]
 		end
+
+		attr_reader :site
+
 	end
 end

--- a/app/helpers.rb
+++ b/app/helpers.rb
@@ -53,9 +53,9 @@ module Tint
 					"<input type='date' name='#{name}' value='#{date && date.strftime("%F")}' />"
 				elsif value.is_a?(String) && value.length > 50
 					"<textarea name='#{name}'>#{value}</textarea>"
-				elsif key && (options = PROJECT_CONFIG["options"][ActiveSupport::Inflector.pluralize(key)])
+				elsif key && (options = site.config["options"][ActiveSupport::Inflector.pluralize(key)])
 					render_select(name, value, options)
-				elsif key && (options = PROJECT_CONFIG["options"][key])
+				elsif key && (options = site.config["options"][key])
 					render_multiple_select(name, value, options)
 				else
 					"<input type='text' name='#{name}' value='#{value}' />"
@@ -120,7 +120,7 @@ module Tint
 			end
 
 			def multiple_select?(key)
-				!!PROJECT_CONFIG["options"][key]
+				!!site.config["options"][key]
 			end
 		end
 	end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -8,7 +8,7 @@ module Tint
 		end
 
 		def index?
-			!!user
+			false
 		end
 
 		def show?

--- a/app/policies/file_policy.rb
+++ b/app/policies/file_policy.rb
@@ -2,12 +2,16 @@ require_relative 'application_policy'
 
 module Tint
 	class FilePolicy < Tint::ApplicationPolicy
+		def index?
+			user && user[:user_id] == record.user_id
+		end
+
 		def update?
-			!!user
+			user && user[:user_id] == record.user_id
 		end
 
 		def destroy?
-			!!user
+			user && user[:user_id] == record.user_id
 		end
 	end
 end

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -1,12 +1,8 @@
 require_relative 'application_policy'
 
 module Tint
-	class DirectoryPolicy < Tint::ApplicationPolicy
+	class SitePolicy < Tint::ApplicationPolicy
 		def index?
-			user && user[:user_id] == record.user_id
-		end
-
-		def update?
 			user && user[:user_id] == record.user_id
 		end
 	end

--- a/app/site.rb
+++ b/app/site.rb
@@ -1,0 +1,40 @@
+require "git"
+
+module Tint
+	class Site
+		def initialize(options)
+			@options = options
+		end
+
+		def route(sub='')
+			"/#{@options[:site_id]}/#{sub}"
+		end
+
+		def fn
+			@options[:fn]
+		end
+
+		def user_id
+			@options[:user_id] && @options[:user_id].to_i
+		end
+
+		def cache_path
+			@options[:cache_path] ||= Pathname.new(ENV.fetch("CACHE_PATH")).
+			                          realpath.join(@options[:site_id].to_s)
+			@options[:cache_path].mkpath
+			@options[:cache_path]
+		end
+
+		def config
+			@config ||= YAML.safe_load(open(cache_path.join(".tint.yml")), [Date, Time])
+		end
+
+		def file(path)
+			Tint::File.new(self, path)
+		end
+
+		def git
+			@git ||= Git.open(cache_path)
+		end
+	end
+end

--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -1,8 +1,1 @@
-<nav>
-	<form method="post" action="/build">
-		<button type="submit">Build</button>
-	</form>
-	<ul>
-		<li><a href="/files">Edit Files</a></li>
-	</ul>
-</nav>
+Add a site, list of sites, etc

--- a/app/views/site/index.erb
+++ b/app/views/site/index.erb
@@ -1,0 +1,10 @@
+<h1><%= site.fn %></h1>
+
+<nav>
+	<form method="post" action="<%= site.route("build") %>">
+		<button type="submit">Build</button>
+	</form>
+	<ul>
+		<li><a href="<%= site.route("files") %>">Edit Files</a></li>
+	</ul>
+</nav>

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -1,16 +1,21 @@
 require "minitest/autorun"
+require_relative "../app/site"
 require_relative "../app/file"
 
-module Tint
-	PROJECT_PATH = ""
-end
-
 describe File do
-	let(:subject) { Tint::File.new(path) }
+	let(:site) do
+		Tint::Site.new(
+			site_id: 1,
+			user_id: 1,
+			cache_path: Pathname.new(__FILE__).dirname.join("data"),
+			fn: "Test Site"
+		)
+	end
+	let(:subject) { site.file(path) }
 
 	describe "#directory?" do
 		describe "when path is directory" do
-			let(:path) { "test/data/directory" }
+			let(:path) { "directory" }
 
 			it "should be true" do
 				subject.directory?.must_equal true
@@ -18,7 +23,7 @@ describe File do
 		end
 
 		describe "when path is not a directory" do
-			let(:path) { "test/data/directory/file" }
+			let(:path) { "directory/file" }
 
 			it "should be false" do
 				subject.directory?.must_equal false


### PR DESCRIPTION
Routes are all relative to /:site now and everything loads the site at
that id to determine its settings.  If SITE_PATH is set, then no DB is
created and instead a Tint::Site with the correct id is ginned up.
Everything should work as it did before so long as SITE_PATH is set.

This basically gets us to multitenancy.  Though users cannot yet create
a site (#42) and we do not yet clone or sync with a remote to
meaningfully create the local cache.

However, this *does* contain enough of the permissions bits to restrict
a user to only see their own sites.

Closes #41