### PR TITLE
Preserve whitespace and HTML through TinyMCE

### DIFF
--- a/app/public/marked.js
+++ b/app/public/marked.js
@@ -55,6 +55,32 @@ block.html = replace(block.html)
   (/tag/g, block._tag)
   ();
 
+/**
+ * GFM Block Grammar
+ */
+
+block.gfm = merge({}, block, {
+  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,
+  paragraph: /^/,
+  heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
+});
+
+block.gfm.paragraph = replace(block.paragraph)
+  ('hr', block.hr)
+  ('heading', block.gfm.heading)
+  ('lheading', block.lheading)
+  ('blockquote', block.blockquote)
+  ('tag', '<' + block._tag)
+  ('def', block.def)
+  ('(?!', '(?!'
+    + block.gfm.fences.source.replace('\\1', '\\2') + '|'
+    + block.list.source.replace('\\1', '\\3') + '|')
+  ();
+
+/**
+ * Normal Block Grammar
+ */
+
 block.paragraph = replace(block.paragraph)
   ('hr', block.hr)
   ('heading', block.heading)
@@ -64,27 +90,7 @@ block.paragraph = replace(block.paragraph)
   ('def', block.def)
   ();
 
-/**
- * Normal Block Grammar
- */
-
 block.normal = merge({}, block);
-
-/**
- * GFM Block Grammar
- */
-
-block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,
-  paragraph: /^/,
-  heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
-});
-
-block.gfm.paragraph = replace(block.paragraph)
-  ('(?!', '(?!'
-    + block.gfm.fences.source.replace('\\1', '\\2') + '|'
-    + block.list.source.replace('\\1', '\\3') + '|')
-  ();
 
 /**
  * GFM + Tables Block Grammar

--- a/app/views/files/text.erb
+++ b/app/views/files/text.erb
@@ -2,6 +2,7 @@
 <form action="<%= path %>" method="post">
 	<input type="hidden" name="_method" value="PUT" />
 	<%= render_yml(frontmatter) if frontmatter %>
+	<small>Shift+Enter to insert a raw newline (in code blocks, etc)</small>
 	<textarea name="content"></textarea>
 	<button type="submit">Save</button>
 </form>
@@ -17,11 +18,16 @@
 <script type="text/javascript">
 	window.addEventListener('load', function() {
 		var content = document.querySelector('textarea[name=content]');
-		content.value = marked(content.value);
+		content.value = marked(content.value.replace(/\t/, "&#9;"));
 		tinymce.init({
 			selector: 'textarea[name=content]',
 			menubar: false,
-			toolbar: 'undo redo | formatselect | bold italic numlist bullist | blockquote link image'
+			toolbar: 'undo redo | formatselect | bold italic numlist bullist | blockquote link image',
+			entity_encoding: 'raw',
+
+			// Show and preserve whitspace
+			whitespace_elements: 'p',
+			content_style: 'p { white-space: pre-wrap; }'
 		});
 
 		document.querySelector("form").addEventListener("submit", function(e) {
@@ -34,7 +40,7 @@
 					content.value = markdown;
 					HTMLFormElement.prototype.submit.call(document.querySelector("form"));
 				}
-			});
+			}, { keepHtml: true, keepWhitespace: true });
 		});
 	});
 </script>


### PR DESCRIPTION
A few TinyMCE settings, but also adding some stuff to upndown to allow
the resulting markdown we create to keep more of the formatting (esp
whitespace and HTML attributes).

Closes #83
Closes #97