### PR TITLE
Blank params are nil, set site params to required

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -68,6 +68,10 @@ module Tint
 			end
 		end
 
+		before do
+			blank_is_nil!(params)
+		end
+
 		after do
 			verify_authorized
 		end
@@ -354,11 +358,7 @@ module Tint
 					end
 				end
 			else
-				if data == ""
-					nil
-				else
-					data
-				end
+				data
 			end
 		end
 
@@ -387,6 +387,19 @@ module Tint
 				)
 			else
 				Tint::Site.new(DB[:sites][site_id: params['site'].to_i])
+			end
+		end
+
+		def blank_is_nil!(hash)
+			hash.each do |k, v|
+				case v
+				when Hash
+					blank_is_nil!(v)
+				when Array
+					hash[k] = v.map { |x| x.to_s == "" ? nil : x }
+				else
+					hash[k] = nil if v.to_s == ""
+				end
 			end
 		end
 	end

--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -7,7 +7,7 @@
 <h1>New Site</h1>
 
 <form method="POST" action="/">
-	<label>Site name: <input type="text" name="fn" /></label>
-	<label>Git remote: <input type="text" name="remote" /></label>
+	<label>Site name: <input required="required" type="text" name="fn" /></label>
+	<label>Git remote: <input required="required" type="text" name="remote" /></label>
 	<button type="submit">Add</button>
 </form>

--- a/app/views/site/index.erb
+++ b/app/views/site/index.erb
@@ -21,11 +21,11 @@
 
 	<label>
 		Name
-		<input type="text" name="fn" value="<%= site.fn %>" />
+		<input required="required" type="text" name="fn" value="<%= site.fn %>" />
 	</label>
 	<label>
 		Remote
-		<input type="text" name="remote" value="<%= site.remote %>" />
+		<input required="required" type="text" name="remote" value="<%= site.remote %>" />
 	</label>
 
 	<button type="submit">Update</button>


### PR DESCRIPTION
The nil gets caught by the database, whereas currently blank string does
not.  Really, we already had other code to treat blanks as nil anyway.
This is what we want.