### PR TITLE
Make add+commit operations atomic

### DIFF
--- a/app/directory.rb
+++ b/app/directory.rb
@@ -18,17 +18,5 @@ module Tint
 
 			@files = files.sort_by { |f| [f.directory? ? 0 : 1, f.name] }
 		end
-
-		def upload(file, name=file[:filename])
-			mkpath
-
-			join(name).open("w") do |f|
-				until file[:tempfile].eof?
-					f.write file[:tempfile].read(4096)
-				end
-			end
-
-			site.file(relative_path.join(file[:filename]))
-		end
 	end
 end


### PR DESCRIPTION
File writes, removes, renames, etc are all done in a temporary, fresh
clone seperate from the cache directory.  Changes are pushed to upstream
after commit, then the cache is sync'd.

If push fails (that is, someone else pushed while we were writing) then
we do try again.

Closes #77