### PR TITLE
Hide token from people who don't know it

### DIFF
--- a/app/build_script.rb
+++ b/app/build_script.rb
@@ -2,7 +2,7 @@ require "digest"
 require "shellwords"
 
 module Tint
-	def self.build_script(job_id, site_id, remote)
+	def self.build_script(job_id, site_id, remote, token)
 		job_id = Shellwords.escape(job_id.to_s)
 		site_id = Shellwords.escape(site_id.to_s)
 		remote = Shellwords.escape(remote.to_s)
@@ -28,7 +28,7 @@ module Tint
 		cd /tmp
 		tar --posix --one-file-system --owner=33 --group=33 \\
 			-cf #{tar} #{job_id}/
-		curl -u #{job_id}:#{Tint.token(job_id)} \\
+		curl -u #{job_id}:#{token} \\
 			#{app_url}/#{site_id}/deploy \\
 			--data-binary @#{tar}
 

--- a/app/controllers/build.rb
+++ b/app/controllers/build.rb
@@ -19,7 +19,8 @@ module Tint
 				Tint.build_script(
 					payload['job']['id'],
 					payload['site']['site_id'],
-					payload['site']['remote']
+					payload['site']['remote'],
+					payload['job']['token']
 				)
 			end
 

--- a/app/local_job.rb
+++ b/app/local_job.rb
@@ -39,7 +39,8 @@ module Tint
 				tmp.puts(Tint.build_script(
 					job_id,
 					site.to_h[:site_id],
-					site.remote
+					site.remote,
+					Tint.token(job_id)
 				))
 				tmp.flush
 				if system("env -i - PATH=\"#{ENV['PATH']}\" GEM_PATH=\"#{ENV['GEM_PATH']}\" /bin/sh #{Shellwords.escape(tmp.path)}")

--- a/app/travis_job.rb
+++ b/app/travis_job.rb
@@ -49,7 +49,7 @@ module Tint
 			@status = :created
 			self.class.queue_dir.join("10-created.d").join("#{job_id}.json").open('w') do |f|
 				f.puts(JSON.dump(
-					job: { id: job_id },
+					job: { id: job_id, token: Tint.token(job_id) },
 					site: site.to_h
 				))
 			end


### PR DESCRIPTION
Pass it through the job queues so that only our systems see the token.
Anyone with the token can deploy to the site, so it's a pretty big deal.

Closes #180