### PR TITLE
Turn off warnings in test output.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'rake/testtask'
 
 Rake::TestTask.new do |t|
 	t.pattern = "test/**/*_test.rb"
+	t.warning = false
 end
 
 task :environment do


### PR DESCRIPTION
As much as I don't like turning off warnings all of the current ones are
for libraries we don't have control over and they are making the test
output fairly messy.