### PR TITLE
Show time and textareas.

### DIFF
--- a/app/input.rb
+++ b/app/input.rb
@@ -10,19 +10,20 @@ module Tint
 		def self.type(key, value, site)
 			return unless scalarish?(value)
 
+			norm_key = key.to_s.downcase
 			if select_options(site, key)
 				MultipleSelect
 			elsif select_options(site, ActiveSupport::Inflector.pluralize(key.to_s))
 				Select
 			elsif [true, false].include? value
 				Checkbox
-			elsif key.to_s.end_with?("_path") || key.to_s.end_with?("_paths")
+			elsif norm_key.end_with?("_path") || norm_key.end_with?("_paths")
 				File
-			elsif key.to_s.downcase.end_with?("_datetime") || key.to_s.downcase == "datetime" || value.is_a?(::Time)
+			elsif norm_key.end_with?("_datetime") || norm_key == "datetime" || value.is_a?(::Time)
 				DateTime
-			elsif key.to_s.downcase.end_with?("_date") || key.to_s.downcase == "date" || value.is_a?(::Date)
+			elsif norm_key.end_with?("_date") || norm_key == "date" || value.is_a?(::Date)
 				Date
-			elsif value.is_a?(String) && value.length > 50
+			elsif norm_key == "description" || norm_key.end_with?("_text") || (value.is_a?(String) && value.length > 50)
 				Textarea
 			else
 				Text

--- a/app/input.rb
+++ b/app/input.rb
@@ -23,6 +23,8 @@ module Tint
 				DateTime
 			elsif norm_key.end_with?("_date") || norm_key == "date" || value.is_a?(::Date)
 				Date
+			elsif norm_key == "time" || norm_key.end_with?("_time")
+				Time
 			elsif norm_key == "description" || norm_key.end_with?("_text") || (value.is_a?(String) && value.length > 50)
 				Textarea
 			else
@@ -69,6 +71,9 @@ module Tint
 			def value
 				::Date.parse(super.to_s) if super.to_s != ""
 			end
+		end
+
+		class Time < Base
 		end
 
 		class Select < Base

--- a/app/views/inputs/time.slim
+++ b/app/views/inputs/time.slim
@@ -1,0 +1,1 @@
+input type="time" name=name value=value

--- a/test/input_test.rb
+++ b/test/input_test.rb
@@ -112,6 +112,22 @@ describe Tint::Input do
 			end
 		end
 
+		describe "when the key is time" do
+			let(:key) { "time" }
+
+			it "should return Time" do
+				assert_equal(Tint::Input::Time, subject)
+			end
+		end
+
+		describe "when the key ends with _time" do
+			let(:key) { "closing_time" }
+
+			it "should return Time" do
+				assert_equal(Tint::Input::Time, subject)
+			end
+		end
+
 		describe "when the value is a string longer than 50 characters" do
 			let(:tvalue) { "A" * 51 }
 
@@ -205,6 +221,16 @@ describe Tint::Input do
 				let(:val) { [{}, "one"] }
 
 				it { assert_equal(false, subject) }
+			end
+		end
+	end
+
+	describe Tint::Input::Time do
+		let(:subject) { Tint::Input::Time.new(:time, :time, nil, nil) }
+
+		describe "#render" do
+			it "should return a string" do
+				assert_equal(String, subject.render.class)
 			end
 		end
 	end

--- a/test/input_test.rb
+++ b/test/input_test.rb
@@ -120,6 +120,22 @@ describe Tint::Input do
 			end
 		end
 
+		describe "when the key is description" do
+			let(:key) { "description" }
+
+			it "should return Textarea" do
+				assert_equal(Tint::Input::Textarea, subject)
+			end
+		end
+
+		describe "when key ends in _text" do
+			let(:key) { "something_text" }
+
+			it "should return Textarea" do
+				assert_equal(Tint::Input::Textarea, subject)
+			end
+		end
+
 		describe "arrays" do
 			describe "when array is scalarish" do
 				let(:tvalue) { ["one.ext", "two.ext"] }


### PR DESCRIPTION
Allow YML to specify whether or not a time input or a textarea should be displayed.

Resolves two of the points on #14 