### PR TITLE
No need to minify CSS

### DIFF
--- a/app/controllers/asset.rb
+++ b/app/controllers/asset.rb
@@ -11,7 +11,6 @@ module Tint
 			sprockets.append_path "assets/stylesheets"
 			sprockets.append_path "assets/javascripts"
 			sprockets.append_path "assets/images"
-			sprockets.css_compressor = :scss
 
 			get "/assets/*" do
 				skip_authorization


### PR DESCRIPTION
Without this, scss still works, but emits in a more readable fashion.