### PR TITLE
Add user as owner on site create

### DIFF
--- a/app/controllers/site.rb
+++ b/app/controllers/site.rb
@@ -38,10 +38,14 @@ module Tint
 					begin
 						subdomain = WORDLIST.sample(3).join('-')
 						site_id = Tint.db[:sites].insert(
-							user_id: pundit_user.user_id,
 							fn: params[:fn],
 							remote: params[:remote],
 							domain: DOMAIN && "#{subdomain}.#{DOMAIN}"
+						)
+						Tint.db[:site_users].insert(
+							site_id: site_id,
+							user_id: pundit_user.user_id,
+							role: "owner"
 						)
 					rescue Sequel::UniqueConstraintViolation
 						retry


### PR DESCRIPTION
We used to have a user_id directly on site, but that changed with
multi-user.  So create an "owner" role for the current user when
creating a site.