### PR TITLE
Record what user asked for a default file

### DIFF
--- a/app/controllers/file.rb
+++ b/app/controllers/file.rb
@@ -181,7 +181,7 @@ module Tint
 
 						raise ArgumentError, "Must specify a valid build system" unless build_system
 
-						site.commit_with("Created default #{build_system} #{template}") do |dir|
+						site.commit_with("Created default #{build_system} #{template}", pundit_user) do |dir|
 							FileUtils.cp(
 								Pathname.new(__FILE__).join("../../../templates/#{build_system}/#{template}"),
 								dir.join(template)


### PR DESCRIPTION
When creating a default Makefile or .tint.yml, record what user
requested it as the git author.

Also, in production, without this set it causes an error because it
cannot infer a useful author for the commit.