### PR TITLE
Fix destroy site

### DIFF
--- a/app/controllers/site.rb
+++ b/app/controllers/site.rb
@@ -119,6 +119,8 @@ module Tint
 					authorize site, :destroy?
 
 					site.clear_cache!
+					site.ssh_public_key_path.unlink
+					site.ssh_private_key_path.unlink
 					Tint.db[:sites].where(site_id: params[:site]).delete
 
 					redirect to("/")

--- a/migrations/1476284405_site_users_association_cascade.rb
+++ b/migrations/1476284405_site_users_association_cascade.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+	change do
+		alter_table :site_users do
+			# When site is removed, remove association to user
+			drop_foreign_key [:site_id]
+			add_foreign_key [:site_id], :sites, on_delete: :cascade
+
+			# When user is removed, remove association to site
+			drop_foreign_key [:user_id]
+			add_foreign_key [:user_id], :users, on_delete: :cascade
+		end
+	end
+end


### PR DESCRIPTION
By removing associations to users when site is removed, and also cleanup generated SSH keys.