### PR TITLE
Do not generate ids for Markdown headings

### DIFF
--- a/app/public/marked.js
+++ b/app/public/marked.js
@@ -801,10 +801,7 @@ Renderer.prototype.html = function(html) {
 Renderer.prototype.heading = function(text, level, raw) {
   return '<h'
     + level
-    + ' id="'
-    + this.options.headerPrefix
-    + raw.toLowerCase().replace(/[^\w]+/g, '-')
-    + '">'
+    + '>'
     + text
     + '</h'
     + level


### PR DESCRIPTION
Or else these get saved and no headings use markdown anymore.  And
they're autogenerated anyway.  We don't want them.