### PR TITLE
Allow user to add links from TinyMCE

### DIFF
--- a/app/public/markdown_editing.js
+++ b/app/public/markdown_editing.js
@@ -7,7 +7,13 @@ window.addEventListener('load', function() {
 		statusbar: false,
 		toolbar: 'undo redo | formatselect | bold italic numlist bullist | blockquote link image',
 		entity_encoding: 'raw',
-		plugins: "autoresize",
+		plugins: "autoresize, link",
+		document_base_url: "http://" + site_domain + "/",
+		relative_urls: false,
+		remove_script_host: true,
+		target_list: false,
+		link_title: false,
+		// Can have a link_list that gets links from JSON, URL, or function and displays
 
 		// Show and preserve whitspace
 		whitespace_elements: 'p',

--- a/app/views/layouts/files.slim
+++ b/app/views/layouts/files.slim
@@ -1,6 +1,7 @@
 javascript:
 	// @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-3.0
 	var files_path = "#{site.route("files")}";
+	var site_domain = "#{site.domain}";
 	// @license-end
 
 header


### PR DESCRIPTION
URLs inserted to paths inside the published site will be inserted as
absolute paths but without the scheme or domain.  External links will be
preserved as entered.

Closes #252