### PR TITLE
Allow options to come from project files

### DIFF
--- a/app/directory.rb
+++ b/app/directory.rb
@@ -6,7 +6,7 @@ module Tint
 			site.resource(relative_path.join(path))
 		end
 
-		def children
+		def children(include_parent=true)
 			@children ||= begin
 				children = exist? ? path.children(false).map(&method(:resource)) : []
 
@@ -17,7 +17,7 @@ module Tint
 					children = children.reject { |child| hidden.include?(child.path) }
 				end
 
-				if relative_path.to_s != "."
+				if include_parent && relative_path.to_s != "."
 					parent = self.class.new(site, relative_path.dirname, "..")
 					children.unshift(parent)
 				end

--- a/app/input.rb
+++ b/app/input.rb
@@ -88,10 +88,17 @@ module Tint
 		protected
 
 			def format_options(options)
-				if options.is_a? Array
+				case options
+				when Array
 					options.map { |value| [value, value] }
-				elsif options.is_a? Hash
+				when Hash
 					options.map { |value, display| [value, display] }
+				when Site::Config::Basenames
+					format_options(site.resource(options).children(false).map { |file|
+						file.basename(file.extname).to_s
+					})
+				when String # Filenames
+					format_options(site.resource(options).children(false).map(&:fn))
 				else
 					fail ArgumentError, "options must be a Hash or an Array"
 				end

--- a/app/site.rb
+++ b/app/site.rb
@@ -10,6 +10,20 @@ require_relative "path_helpers"
 
 module Tint
 	class Site
+		module Config
+			class Basenames < String
+				yaml_tag "!basenames"
+
+				def encode_with(coder)
+					coder.represent_scalar("basenames", self)
+				end
+
+				def init_with(coder)
+					self << coder.scalar
+				end
+			end
+		end
+
 		def initialize(options)
 			@options = options
 		end
@@ -80,7 +94,7 @@ module Tint
 		end
 
 		def unsafe_config
-			config_file.exist? ? YAML.safe_load(config_file.open, [Date, Time]) : {}
+			config_file.exist? ? YAML.safe_load(config_file.open, [Date, Time, Config::Basenames]) : {}
 		end
 
 		def config

--- a/templates/jekyll/.tint.yml
+++ b/templates/jekyll/.tint.yml
@@ -1,3 +1,6 @@
+options:
+  layouts: !basenames "_layouts/"
+
 hidden_paths:
   - .*
   - Makefile


### PR DESCRIPTION
Either the filename or the extensionless filename is used as the
options.

Add a default extensionless option for "layouts" in jekyll sites so that
the layout field becomes a drop-down with correct options.

Closes #277