### PR TITLE
User can create a new file from a template

### DIFF
--- a/app/directory.rb
+++ b/app/directory.rb
@@ -1,9 +1,22 @@
+require "active_support/inflector/methods"
 require_relative "resource"
 
 module Tint
 	class Directory < Resource
 		def resource(path)
 			site.resource(relative_path.join(path))
+		end
+
+		def collection_name
+			ActiveSupport::Inflector.singularize(fn.sub(/[^A-Za-z0-9]+/, ''))
+		end
+
+		def templates
+			return [] unless exist?
+
+			path.children(false).select { |file|
+				file.to_s.start_with?(".template")
+			}.map { |file| file.to_s.split(".", 3).last }
 		end
 
 		def children(include_parent=true)

--- a/app/file.rb
+++ b/app/file.rb
@@ -124,8 +124,7 @@ module Tint
 		def filename_frontmatter_candidates
 			@filename_frontmatter_candidates ||=
 				(site.config["filename_frontmatter"] || {}).map do |(glob, pieces)|
-					matches = Pathname.glob([parent.path.join(glob), site.cache_path.join(glob)])
-					matches.include?(path) ? pieces : nil
+					relative_path.fnmatch?(glob) || basename.fnmatch?(glob) ? pieces : nil
 				end.compact
 		end
 

--- a/app/file.rb
+++ b/app/file.rb
@@ -70,7 +70,7 @@ module Tint
 			end
 
 			# From frontmatter takes precedence
-			from_front = YAML.safe_load(open(path), [Date, Time]) || {} rescue {}
+			from_front = YAML.safe_load(open(path), [Date, Time, Now]) || {} rescue {}
 			if from_filename.empty?
 				from_front
 			elsif from_filename.class != from_front.class
@@ -184,6 +184,13 @@ module Tint
 		end
 
 		class IncompatibleFrontmatter < TypeError
+		end
+
+		class Now < String
+			yaml_tag "!now"
+			def init_with(_coder)
+				self << Time.now.iso8601
+			end
 		end
 	end
 end

--- a/app/views/files/index.slim
+++ b/app/views/files/index.slim
@@ -7,6 +7,11 @@
 		input type="file" name="file" required="required"
 		button type="submit" Upload
 
+	- if object.templates.length > 0
+		ul.templates
+			- object.templates.each do |ext|
+				li: a href=object.resource(".template.#{ext}").route = "+ New #{object.collection_name.capitalize} (#{ext})"
+
 	- unless moves.empty?
 		ul
 			- moves.each do |file|

--- a/app/views/files/text.slim
+++ b/app/views/files/text.slim
@@ -2,7 +2,8 @@ form#content enctype="multipart/form-data" action=path method="post"
 	input type="hidden" name="_method" value="PUT"
 
 	header
-		a href="?source" Source
+		- unless path.split("/").last.start_with?(".template")
+			a href="?source" Source
 
 		label
 			| Page Title

--- a/assets/stylesheets/file.scss
+++ b/assets/stylesheets/file.scss
@@ -98,4 +98,18 @@
 		list-style-type: none;
 		padding: 0;
 	}
+
+	.templates {
+		list-style-type: none;
+		padding: 0;
+
+		li {
+			display: inline;
+		}
+
+		a {
+			@extend %button;
+			@extend %small-button;
+		}
+	}
 }

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -221,5 +221,21 @@ describe Tint::File do
 			end
 		end
 
+		describe "nonexistant file" do
+			let(:path) { "filename_frontmatter/2015-01-01-this-file-is-not-here.md" }
+
+			describe "#frontmatter" do
+				it "should return from filename" do
+					assert_equal({
+						"title" => "this-file-is-not-here",
+						"date" => Date.new(2015, 01, 01)
+					}, subject.frontmatter)
+				end
+			end
+
+			describe "#relative_path_with_frontmatter" do
+				it { assert_equal(subject.relative_path_with_frontmatter, subject.relative_path) }
+			end
+		end
 	end
 end


### PR DESCRIPTION
Instead of blindly copying the template, open it in the editor and cause
a file of a reasonable name to be generated on save.

If there is filename frontmatter defined, that filename will be used,
otherwise it will use UUID-slug.extension

Closes #27