### PR TITLE
Better collection names

### DIFF
--- a/app/directory.rb
+++ b/app/directory.rb
@@ -7,8 +7,14 @@ module Tint
 			site.resource(relative_path.join(path))
 		end
 
-		def collection_name
-			ActiveSupport::Inflector.singularize(fn.sub(/[^A-Za-z0-9]+/, ''))
+		def collection_name(count=1)
+			base = relative_path.to_s.gsub(/[^A-Za-z0-9]+/, ' ').strip
+
+			if count == 1
+				ActiveSupport::Inflector.singularize(base)
+			else
+				ActiveSupport::Inflector.pluralize(base)
+			end
 		end
 
 		def templates

--- a/app/views/layout.slim
+++ b/app/views/layout.slim
@@ -21,7 +21,7 @@ html
 							- if site.cloned?
 								li: a href=site.route("files") class=("active" if controller == :file and !site.collections.include?(resource)) File Manager
 								- site.collections.each do |collection|
-									li: a href=collection.route class=("active" if controller == :file and collection == resource) = collection.collection_name.titlecase
+									li: a href=collection.route class=("active" if controller == :file and collection == resource) = collection.collection_name(2).titlecase
 							- if policy(site).manage_users?
 								li: a href=site.route("users/") Manage Users
 				form method="post" action="/auth/login"


### PR DESCRIPTION
Get name from whole relative path (in case of multiple directories with
same leaf name:  blog/_posts and news/_posts) and allow for both
singular and plural form.

Use plural form in sidebar.

Closes #322