### PR TITLE
Basic New Site flow

### DIFF
--- a/app/git_providers/github.rb
+++ b/app/git_providers/github.rb
@@ -5,9 +5,13 @@ require "json"
 module Tint
 	module GitProviders
 		class Github
+			attr_reader :nickname
+
 			def initialize(payload)
-				token = JSON.parse(payload)["credentials"]["token"]
+				payload = JSON.parse(payload)
+				token = payload["credentials"]["token"]
 				@github = ::Github.new(oauth_token: token, per_page: 100, auto_pagination: true)
+				@nickname = payload["info"]["nickname"]
 			end
 
 			def repositories(exclude: [])

--- a/app/git_providers/gitlab.rb
+++ b/app/git_providers/gitlab.rb
@@ -4,12 +4,15 @@ require "json"
 module Tint
 	module GitProviders
 		class Gitlab
+			attr_reader :nickname
+
 			def initialize(payload)
 				omniauth = JSON.parse(payload)
 				@gitlab = ::Gitlab.client(
 					endpoint: "#{omniauth["site"]}/api/v3",
 					private_token: omniauth["credentials"]["token"]
 				)
+				@nickname = omniauth["info"]["username"]
 			end
 
 			def repositories(exclude: [])

--- a/app/views/index.slim
+++ b/app/views/index.slim
@@ -1,32 +1,7 @@
+h1 Sites
+
 ul
 	- sites.each do |site|
 		li: a href=site.route = site.fn
 
-a href="/auth/login" Associate Another Identity
-
-h1 New Site
-form method="POST" action="/"
-	label
-		| Site name:
-		input type="text" name="fn" required="required"
-	label
-		| Git remote:
-		input type="text" name="remote" required="required"
-	button type="submit" Add
-
-- if git_providers.length > 0
-	h1 Or, choose from the following repositories
-
-	- git_providers.each do |provider|
-		- provider_name = provider.class.name.split("::").last
-		h1 = "On #{provider_name}"
-
-		ul
-			- provider.repositories(exclude: repos).each do |repo|
-				li
-					a href=repo[:link] title=repo[:description] = repo[:fn]
-					form method="POST" action="/"
-						input type="hidden" name="provider" value=provider_name.downcase
-						input type="hidden" name="fn" value=repo[:fn]
-						input type="hidden" name="remote" value=repo[:remote]
-						button type="submit" Add
+a href="/new" Add Site

--- a/app/views/new.slim
+++ b/app/views/new.slim
@@ -1,0 +1,28 @@
+h1 New Site
+
+- unless git_providers.empty?
+	section
+		h1 From one of your git providers
+
+		ul
+			- git_providers.each do |(id, provider)|
+				- provider_name = provider.class.name.split("::").last
+				li
+					a href="?from=#{id}"
+						= provider_name
+						- if provider.respond_to?(:nickname) && provider.nickname
+							= " (#{provider.nickname})"
+
+a href="/auth/login" Add a new provider
+
+section
+	h1 or configure your site manually
+
+	form method="POST" action="/"
+		label
+			| Site name:
+			input type="text" name="fn" required="required"
+		label
+			| Git remote:
+			input type="text" name="remote" required="required"
+		button type="submit" Add

--- a/app/views/new_from.slim
+++ b/app/views/new_from.slim
@@ -1,0 +1,11 @@
+h1 New Site From
+
+ul
+	- git_provider.repositories(exclude: repos).each do |repo|
+		li
+			a href=repo[:link] title=repo[:description] = repo[:fn]
+			form method="POST" action="/"
+				input type="hidden" name="git_provider" value=git_provider_name.downcase
+				input type="hidden" name="fn" value=repo[:fn]
+				input type="hidden" name="remote" value=repo[:remote]
+				button type="submit" Add

--- a/assets/stylesheets/site.scss
+++ b/assets/stylesheets/site.scss
@@ -1,0 +1,7 @@
+@import "variables";
+@import "mixins";
+
+a[href="/auth/login"],
+a[href="/new"] {
+	@extend %button;
+}


### PR DESCRIPTION
Instead of listing every possible option for creation right on the
homepage, break it up a bit.

Now the homepage is just existant sites, and an "Add Site" button.

This takes them to a page listing configured git providers, with an "Add
Provider" button and also a manual site creation form at the very
bottom.

Selecting a configured git provider (you can have more than one github
configured, so disambiguation is done with username) shows the same list
of repos (minus ones already used as sites) as before, with an "Add"
button for each one.

Closes #324