### PR TITLE
Reorganize editor views

### DIFF
--- a/app/file.rb
+++ b/app/file.rb
@@ -33,6 +33,10 @@ module Tint
 			[".yaml", ".yml"].include? extension
 		end
 
+		def template?
+			name.start_with?(".template")
+		end
+
 		def stream(force_binary=false)
 			if !force_binary && text?
 				path.each_line.with_index do |line, idx|

--- a/app/views/files/source.slim
+++ b/app/views/files/source.slim
@@ -1,6 +1,9 @@
-h1 = params['filename']
+h1 Source
+
 form action=path method="post"
 	input type="hidden" name="_method" value="PUT"
 	textarea name="source"
 	button type="submit" Save
-a href="?" Back to editor
+
+- if request.query_string == "source"
+	a href="?" Back to editor

--- a/app/views/files/text.slim
+++ b/app/views/files/text.slim
@@ -1,20 +1,21 @@
-form#content enctype="multipart/form-data" action=path method="post"
+form#content enctype="multipart/form-data" action=resource.route method="post"
 	input type="hidden" name="_method" value="PUT"
 
 	header
-		- unless path.split("/").last.start_with?(".template")
+		- unless resource.template?
 			a href="?source" Source
 
-		label
-			| Page Title
-			input type="text" name="data[title]" placeholder="Untitled Page" value=(frontmatter || {})["title"]
+		- if title
+			label
+				| Page Title
+				input type="text" name="data[title]" placeholder="Untitled Page" value=title
 
-	textarea name="content"
+	- if wysiwyg
+		textarea name="content"
 
-	- meta = (frontmatter || {}).reject {|k,v| k == "title"}
-	- if meta.size > 0
+	- if frontmatter.size > 0
 		fieldset.yml
-			== render_yml(meta)
+			== render_yml(frontmatter)
 
 	footer
 		button type="submit" Save and Update

--- a/app/views/files/yml.slim
+++ b/app/views/files/yml.slim
@@ -1,7 +1,0 @@
-form.yml action=path method="post" enctype="multipart/form-data"
-	input type="hidden" name="_method" value="PUT"
-	== render_yml(data)
-
-	button type="submit" Save
-
-== render_log log: resource.log, route: resource.route, button: "revert"

--- a/assets/stylesheets/file.scss
+++ b/assets/stylesheets/file.scss
@@ -6,6 +6,7 @@
 		background: #f8f8f8;
 		border-bottom: 1px solid #d9d9d9;
 		margin: -2rem -2rem 1rem;
+		overflow: hidden;
 		padding: 1rem 2rem;
 
 		> a {


### PR DESCRIPTION
There are conceputally four editor views:

1. WYSIWYG editor with frontmatter editor
2. Frontmatter-only editor (content editor hidden)
3. Source editor (default on non-WYSIWYG files with no frontmatter)
4. Binary file editor (with optional filename frontmatter)

"Page title" is pulled out as special only if the key is present and not
editing a YAML file.

Hiding title and content editor on YAML files makes the page a data-only
editor, so we don't need a seperate view for that.  1 and 2 are thus
both a single view file now.

File with no frontmatter at all go straight to the source editor, since
they would otherwise have a hidden content portion (not WYSIWYG) and no
data fields... which is just an empty page.

Closes #314
Closes #316