### PR TITLE
Much more YAML editor styles

### DIFF
--- a/app/public/yaml.js
+++ b/app/public/yaml.js
@@ -142,11 +142,8 @@ window.addEventListener("load", function() {
 		hydrate(ol);
 	});
 
-	forEach(document.querySelectorAll("form fieldset.yml > label > input[type=file]"), function(input) {
-		fileBrowser(input);
-	});
+	forEach(document.querySelectorAll("form fieldset.yml > label > input[type=file]"), fileBrowser);
 
 	var hidden = document.querySelectorAll("form .hidden");
 	forEach(hidden, function(el) { el.style.display = 'none'; });
-
 });

--- a/app/public/yaml.js
+++ b/app/public/yaml.js
@@ -123,6 +123,7 @@ window.addEventListener("load", function() {
 
 		ol.appendChild(item);
 		hydrateLi(item);
+		renumber(ol, item.previousElementSibling);
 
 		if(item.getBoundingClientRect().bottom > window.innerHeight) {
 			item.scrollIntoView(false);

--- a/app/public/yaml.js
+++ b/app/public/yaml.js
@@ -175,8 +175,8 @@ window.addEventListener("load", function() {
 		hydrate(ol);
 	});
 
-	forEach(document.querySelectorAll("form fieldset.yml > label > input[type=file]"), fileBrowser);
-	forEach(document.querySelectorAll("form fieldset.yml fieldset"), function(fieldset) {
+	forEach(document.querySelectorAll(".yml > label > input[type=file]"), fileBrowser);
+	forEach(document.querySelectorAll(".yml fieldset"), function(fieldset) {
 		if(notInNestedList(fieldset, null)) {
 			hydrateFieldset(fieldset);
 		}

--- a/app/public/yaml.js
+++ b/app/public/yaml.js
@@ -71,6 +71,12 @@ window.addEventListener("load", function() {
 				fileBrowser(fileInput);
 			}
 		});
+
+		forEach(li.querySelectorAll("fieldset"), function(fieldset) {
+			if(fieldset.parentElement !== li && notInNestedList(fieldset, li.parentElement)) {
+				hydrateFieldset(fieldset);
+			}
+		});
 	}
 
 	function renumber(ol, li) {

--- a/app/public/yaml.js
+++ b/app/public/yaml.js
@@ -63,7 +63,7 @@ window.addEventListener("load", function() {
 
 		findOrCreateButton("clone", "Clone").addEventListener("click", function() {
 			var item = li.cloneNode(true);
-			renameAppendHydrate(li.parentElement, item, nameRegexp(li.parentElement));
+			renameAppendHydrate(li.parentElement, item);
 		});
 
 		enableDisableMoveButtons(li.parentNode, li, Array.prototype.indexOf.call(li.parentNode.children, li));

--- a/app/public/yaml.js
+++ b/app/public/yaml.js
@@ -16,8 +16,8 @@ window.addEventListener("load", function() {
 	}
 
 	function enableDisableMoveButtons(ol, li, number) {
-		find(li.children, function(el) { return el.className === "move-up"; }).disabled = number < 1;
-		find(li.children, function(el) { return el.className === "move-down"; }).disabled = number >= ol.children.length - 1;
+		find(li.firstChild.children, function(el) { return el.className === "move-up"; }).disabled = number < 1;
+		find(li.firstChild.children, function(el) { return el.className === "move-down"; }).disabled = number >= ol.children.length - 1;
 	}
 
 	function notInNestedList(el, targetParent) {
@@ -32,12 +32,14 @@ window.addEventListener("load", function() {
 	}
 
 	function hydrateLi(li) {
+		var fieldset = li.firstChild;
+
 		function findOrCreateButton(className, label) {
-			var button = find(li.children, function(el) { return el.className === className; });
+			var button = find(fieldset.children, function(el) { return el.className === className; });
 
 			if(!button) {
 				button = document.createElement("button");
-				li.appendChild(button);
+				fieldset.insertBefore(button, fieldset.firstChild);
 
 				button.type = "button";
 				button.className = className;
@@ -46,11 +48,6 @@ window.addEventListener("load", function() {
 
 			return button;
 		}
-
-		findOrCreateButton("clone", "Clone").addEventListener("click", function() {
-			var item = li.cloneNode(true);
-			renameAppendHydrate(li.parentElement, item, nameRegexp(li.parentElement));
-		});
 
 		findOrCreateButton("move-up", "▲").addEventListener("click", function() {
 			li.parentNode.insertBefore(li, li.previousElementSibling);
@@ -62,6 +59,11 @@ window.addEventListener("load", function() {
 			li.parentNode.insertBefore(li.nextElementSibling, li);
 			renumber(li.parentNode, li);
 			renumber(li.parentNode, li.previousElementSibling);
+		});
+
+		findOrCreateButton("clone", "Clone").addEventListener("click", function() {
+			var item = li.cloneNode(true);
+			renameAppendHydrate(li.parentElement, item, nameRegexp(li.parentElement));
 		});
 
 		enableDisableMoveButtons(li.parentNode, li, Array.prototype.indexOf.call(li.parentNode.children, li));

--- a/app/public/yaml.js
+++ b/app/public/yaml.js
@@ -133,6 +133,26 @@ window.addEventListener("load", function() {
 		});
 	}
 
+	function toggleFieldset(fieldset) {
+		forEach(fieldset.children, function(el) {
+			if(el.nodeName !== "LEGEND") {
+				el.style.display = el.style.display === "none" ? "block" : "none";
+			}
+		});
+	}
+
+	function hydrateFieldset(fieldset) {
+		forEach(fieldset.children, function(el) {
+			if(el.nodeName === "LEGEND") {
+				el.addEventListener("click", function() {
+					toggleFieldset(fieldset);
+				});
+			} else {
+				el.style.display = "none";
+			}
+		});
+	}
+
 	forEach(document.querySelectorAll("form ol[data-key] > li:last-child"), function(li) {
 		var ol = li.parentElement;
 		var button = document.createElement("button");
@@ -143,6 +163,7 @@ window.addEventListener("load", function() {
 	});
 
 	forEach(document.querySelectorAll("form fieldset.yml > label > input[type=file]"), fileBrowser);
+	forEach(document.querySelectorAll("form fieldset.yml > fieldset, form fieldset.yml > fieldset > fieldset"), hydrateFieldset);
 
 	var hidden = document.querySelectorAll("form .hidden");
 	forEach(hidden, function(el) { el.style.display = 'none'; });

--- a/assets/stylesheets/file.scss
+++ b/assets/stylesheets/file.scss
@@ -47,10 +47,44 @@
 		margin: 0 -2rem 1rem;
 		padding: 1rem 2rem;
 
-		legend {
-			font-size: 0.8rem;
-			font-weight: bold;
-			text-transform: uppercase;
+
+		fieldset {
+			background: #ccc;
+			border: none;
+			margin-bottom: 0.5em;
+			padding: 1em;
+
+			legend {
+				cursor: pointer;
+				float: left;
+				font-size: 0.8rem;
+				font-weight: bold;
+				text-transform: uppercase;
+				width: 100%;
+
+				+ * {
+					clear: left;
+					padding-top: 1em;
+				}
+			}
+
+			fieldset,
+			fieldset fieldset fieldset,
+			fieldset fieldset fieldset fieldset fieldset { background: #999; }
+
+			fieldset fieldset,
+			fieldset fieldset fieldset fieldset { background: #ccc; }
+		}
+
+		ol {
+			list-style-type: none;
+			padding: 0;
+
+			li > fieldset > button[type="button"] {
+				background: none;
+				color: #000;
+				float: right;
+			}
 		}
 
 		input {

--- a/assets/stylesheets/file.scss
+++ b/assets/stylesheets/file.scss
@@ -41,61 +41,6 @@
 		width: calc(100% + 4rem);
 	}
 
-	.yml {
-		background: #f8f8f8;
-		border: none;
-		margin: 0 -2rem 1rem;
-		padding: 1rem 2rem;
-
-
-		fieldset {
-			background: #ccc;
-			border: none;
-			margin-bottom: 0.5em;
-			padding: 1em;
-
-			legend {
-				cursor: pointer;
-				float: left;
-				font-size: 0.8rem;
-				font-weight: bold;
-				text-transform: uppercase;
-				width: 100%;
-
-				+ * {
-					clear: left;
-					padding-top: 1em;
-				}
-			}
-
-			fieldset,
-			fieldset fieldset fieldset,
-			fieldset fieldset fieldset fieldset fieldset { background: #999; }
-
-			fieldset fieldset,
-			fieldset fieldset fieldset fieldset { background: #ccc; }
-		}
-
-		ol {
-			list-style-type: none;
-			padding: 0;
-
-			li > fieldset > button[type="button"] {
-				background: none;
-				color: #000;
-				float: right;
-			}
-		}
-
-		input {
-			background: #fff;
-		}
-
-		button[disabled] {
-			display: none;
-		}
-	}
-
 	> footer {
 		background: #f8f8f8;
 		border-top: 1px solid #d9d9d9;
@@ -105,6 +50,61 @@
 		right: 0;
 		text-align: right;
 		width: 75%;
+	}
+}
+
+.yml {
+	background: #f8f8f8;
+	border: none;
+	margin: 0 -2rem 1rem;
+	padding: 1rem 2rem;
+
+
+	fieldset {
+		background: #ccc;
+		border: none;
+		margin-bottom: 0.5em;
+		padding: 1em;
+
+		legend {
+			cursor: pointer;
+			float: left;
+			font-size: 0.8rem;
+			font-weight: bold;
+			text-transform: uppercase;
+			width: 100%;
+
+			+ * {
+				clear: left;
+				padding-top: 1em;
+			}
+		}
+
+		fieldset,
+		fieldset fieldset fieldset,
+		fieldset fieldset fieldset fieldset fieldset { background: #999; }
+
+		fieldset fieldset,
+		fieldset fieldset fieldset fieldset { background: #ccc; }
+	}
+
+	ol {
+		list-style-type: none;
+		padding: 0;
+
+		li > fieldset > button[type="button"] {
+			background: none;
+			color: #000;
+			float: right;
+		}
+	}
+
+	input {
+		background: #fff;
+	}
+
+	button[disabled] {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
Part of #68, #69, and #20 

This implements the show/hide javascript for YAML sections, and styles that are closer to the goal in that area.  Also style the buttons on list items to be top-right icons instead of garish orange goo on the bottom.

Also hide the numbers on lists.  They just take up space for the most part.